### PR TITLE
Add async_timeout

### DIFF
--- a/aioslacker/__init__.py
+++ b/aioslacker/__init__.py
@@ -2,6 +2,7 @@ import asyncio
 from urllib.parse import urlencode
 
 import aiohttp
+import async_timeout
 import requests
 import slacker
 
@@ -79,7 +80,7 @@ class BaseAPI(slacker.BaseAPI):
         _response = None
 
         try:
-            with aiohttp.Timeout(self.timeout, loop=self.loop):
+            with async_timeout.timeout(self.timeout, loop=self.loop):
                 _response = yield from _request
 
             _response.raise_for_status()
@@ -285,7 +286,7 @@ class IncomingWebhook(BaseAPI, slacker.IncomingWebhook):
         _response = None
 
         try:
-            with aiohttp.Timeout(self.timeout, loop=self.loop):
+            with async_timeout.timeout(self.timeout, loop=self.loop):
                 _response = yield from _request
 
             _response.raise_for_status()

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     long_description=read('README.rst'),
     install_requires=[
         'aiohttp>=1.3.0',
+        'async_timeout>=3.0.0',
         'slacker<=0.9.42',
     ],
     packages=['aioslacker'],


### PR DESCRIPTION
For `aiohttp` version 3 the `Timout` has been removed. This PR adds the newer `async_timeout` module to replace the functionality.